### PR TITLE
Changed duration calculation for more framerates.

### DIFF
--- a/plugins/caspar/app/components/LibraryListItem/index.jsx
+++ b/plugins/caspar/app/components/LibraryListItem/index.jsx
@@ -99,8 +99,11 @@ function calculateDurationMs (item) {
    * Extract the framerate from the item - which is written as a fraction
    * @example
    * '1/25' -> 25
+   * '1001/30000' -> 29.97
    */
-  const [, framerate] = item?.framerate.split('/')
+  const [divisor, dividend] = item?.framerate.split('/')
+  const framerate = dividend / divisor;
+
 
   return (item?.duration / framerate) * 1000
 }

--- a/plugins/caspar/app/components/LibraryListItem/index.jsx
+++ b/plugins/caspar/app/components/LibraryListItem/index.jsx
@@ -4,7 +4,7 @@ import './style.css'
 
 import * as asset from '../../utils/asset'
 
-const DEFAULT_DURATION_MS = 5000
+import { calculateDurationMs } from '../../utils/asset'
 
 const DEFAULT_VALUES = {
   [asset.type.still]: {
@@ -78,33 +78,6 @@ function constructPlayableItemInit (libraryAsset) {
       return constructor.fn(libraryAsset)
     }
   }
-}
-
-/**
- * Calculate the duration in milliseconds from an item
- * based on its framerate and duration in frames
- * @param { any } item
- * @returns { Number }
- */
-function calculateDurationMs (item) {
-  if (!item?.duration) {
-    return DEFAULT_DURATION_MS
-  }
-
-  if (!item?.framerate) {
-    return DEFAULT_DURATION_MS
-  }
-
-  /**
-   * Extract the framerate from the item - which is written as a fraction
-   * @example
-   * '1/25' -> 25
-   * '1001/30000' -> 29.97
-   */
-  const [divisor, dividend] = item?.framerate.split('/')
-  const framerate = dividend / divisor;
-
-  return (item?.duration / framerate) * 1000
 }
 
 /**

--- a/plugins/caspar/app/components/LibraryListItem/index.jsx
+++ b/plugins/caspar/app/components/LibraryListItem/index.jsx
@@ -104,7 +104,6 @@ function calculateDurationMs (item) {
   const [divisor, dividend] = item?.framerate.split('/')
   const framerate = dividend / divisor;
 
-
   return (item?.duration / framerate) * 1000
 }
 

--- a/plugins/caspar/app/utils/duration.cjs
+++ b/plugins/caspar/app/utils/duration.cjs
@@ -1,0 +1,67 @@
+const DEFAULT_DURATION_MS = 5000
+
+/**
+ * Calculate the duration in milliseconds from an item
+ * based on its framerate and duration in frames
+ * @param { any } item
+ * @returns { Number }
+ */
+function calculateDurationMs (item) {
+  if (!item) {
+    return DEFAULT_DURATION_MS
+  }
+  // If the item is a still image, return 0
+  if (item.type === 'STILL') {
+    return 0
+  }
+  // If the item has no duration, return the default duration
+  if (isNaN(Number(item?.duration))) {
+    return DEFAULT_DURATION_MS
+  }
+
+  // If the item has no framerate, return the default duration
+  if (!item?.framerate) {
+    return DEFAULT_DURATION_MS
+  }
+
+  /**
+   * Extract the framerate from the item - which is written as a fraction
+   * @example
+   * '1/25' -> 25
+   * '1001/30000' -> 29.97
+   */
+  const framerate = frameRateFractionToDecimal(item?.framerate)
+  if (!framerate) {
+    return DEFAULT_DURATION_MS
+  }
+
+  return (Math.abs(item?.duration) / framerate) * 1000
+}
+
+/**
+ * Calculate the decimal value of a fraction
+ * @example
+ * '30000/1001' -> 29.97
+ * @param {any} fraction
+ * @returns decimal value
+ */
+function frameRateFractionToDecimal (fraction) {
+  const [divisorStr, dividendStr] = String(fraction).split('/')
+
+  const divisor = parseInt(divisorStr)
+  const dividend = parseInt(dividendStr)
+
+  if (Number.isNaN(divisor) || Number.isNaN(dividend)) {
+    return
+  }
+
+  if (divisor <= 0) {
+    return
+  }
+
+  return dividend / divisor
+}
+
+module.exports = {
+  calculateDurationMs
+}

--- a/plugins/caspar/app/utils/tests/duration.test.js
+++ b/plugins/caspar/app/utils/tests/duration.test.js
@@ -1,0 +1,55 @@
+const { calculateDurationMs } = require('../duration.cjs')
+
+test('calculateDurationMs should return 0 for 0 duration (string or number)', () => {
+  // Test for both string and number '0'
+  const itemString = { framerate: '1/25', duration: '0' }
+  const itemNumber = { framerate: '1/25', duration: 0 }
+
+  expect(calculateDurationMs(itemString)).toEqual(0)
+  expect(calculateDurationMs(itemNumber)).toEqual(0)
+})
+
+test('calculateDurationMs should return default time for undefined or invalid duration', () => {
+  // Test for undefined duration
+  const itemUndefinedDuration = { framerate: '1/25', duration: undefined }
+  const itemUndefined = undefined
+  const itemInvalidDuration = { framerate: '1/25', duration: 'invalid' }
+
+  expect(calculateDurationMs(itemUndefinedDuration)).toEqual(5000)
+  expect(calculateDurationMs(itemUndefined)).toEqual(5000)
+  expect(calculateDurationMs(itemInvalidDuration)).toEqual(5000)
+})
+
+test('calculateDurationMs should return default time for undefined framerate or invalid framerate', () => {
+  // Test for undefined or invalid framerate
+  const itemUndefinedFramerate = { framerate: undefined, duration: '0' }
+  const itemInvalidFramerate = { framerate: '0/0', duration: '10' }
+
+  expect(calculateDurationMs(itemUndefinedFramerate)).toEqual(5000)
+  expect(calculateDurationMs(itemInvalidFramerate)).toEqual(5000)
+})
+
+test('calculateDurationMs should return adjusted time for negative duration', () => {
+  const item = {
+    framerate: '1/25',
+    duration: '-100'
+  }
+  expect(calculateDurationMs(item)).toEqual(4000)
+})
+
+test('calculateDurationMs should return correct time for fractional framerate', () => {
+  const item = {
+    framerate: '1001/30000',
+    duration: '30000'
+  }
+  expect(calculateDurationMs(item)).toEqual(1001000)
+})
+
+test('calculateDurationMs should return 0 for STILL image', () => {
+  const item = {
+    type: 'STILL',
+    framerate: '1/25',
+    duration: '100'
+  }
+  expect(calculateDurationMs(item)).toEqual(0)
+})

--- a/plugins/caspar/app/utils/tests/duration.unit.test.js
+++ b/plugins/caspar/app/utils/tests/duration.unit.test.js
@@ -1,0 +1,55 @@
+const { calculateDurationMs } = require('../duration.cjs')
+
+test('calculateDurationMs should return 0 for 0 duration (string or number)', () => {
+  // Test for both string and number '0'
+  const itemString = { framerate: '1/25', duration: '0' }
+  const itemNumber = { framerate: '1/25', duration: 0 }
+
+  expect(calculateDurationMs(itemString)).toEqual(0)
+  expect(calculateDurationMs(itemNumber)).toEqual(0)
+})
+
+test('calculateDurationMs should return default time for undefined or invalid duration', () => {
+  // Test for undefined duration
+  const itemUndefinedDuration = { framerate: '1/25', duration: undefined }
+  const itemUndefined = undefined
+  const itemInvalidDuration = { framerate: '1/25', duration: 'invalid' }
+
+  expect(calculateDurationMs(itemUndefinedDuration)).toEqual(5000)
+  expect(calculateDurationMs(itemUndefined)).toEqual(5000)
+  expect(calculateDurationMs(itemInvalidDuration)).toEqual(5000)
+})
+
+test('calculateDurationMs should return default time for undefined framerate or invalid framerate', () => {
+  // Test for undefined or invalid framerate
+  const itemUndefinedFramerate = { framerate: undefined, duration: '0' }
+  const itemInvalidFramerate = { framerate: '0/0', duration: '10' }
+
+  expect(calculateDurationMs(itemUndefinedFramerate)).toEqual(5000)
+  expect(calculateDurationMs(itemInvalidFramerate)).toEqual(5000)
+})
+
+test('calculateDurationMs should return adjusted time for negative duration', () => {
+  const item = {
+    framerate: '1/25',
+    duration: '-100'
+  }
+  expect(calculateDurationMs(item)).toEqual(4000)
+})
+
+test('calculateDurationMs should return correct time for fractional framerate', () => {
+  const item = {
+    framerate: '1001/30000',
+    duration: '30000'
+  }
+  expect(calculateDurationMs(item)).toEqual(1001000)
+})
+
+test('calculateDurationMs should return 0 for STILL image', () => {
+  const item = {
+    type: 'STILL',
+    framerate: '1/25',
+    duration: '100'
+  }
+  expect(calculateDurationMs(item)).toEqual(0)
+})


### PR DESCRIPTION
Signed-off-by: Simon Mellberg <mellbergsimon@example.com>

# Pull Request Template

## Description

The calculation for duration for media elements did not account for framerates like 29.97 (1001/30000). This PR fixes that small bug.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on my MacBook and got CLS information from a ubuntu machine running caspar.

**Test Configuration**:
* Firmware version: Bridge 1.0.0-beta.6
* Hardware: Ubuntu 22.04.5 LTS, CasparCG 2.4.3 Stable

## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

