### PR TITLE
1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.0.0-beta.6 - [UNRELEASED]
+
 ## 1.0.0-beta.5
 ### Changed
 - Updated caniuse db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## 1.0.0-beta.6 - [UNRELEASED]
+### Changed
+- item.data.caspar.data replaces item.data.templateData for structured template data
+### Added
+- The `item.apply` event
 
 ## 1.0.0-beta.5
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - item.data.caspar.data replaces item.data.templateData for structured template data
 ### Added
 - The `item.apply` event
+- A volume item type for the Caspar plugin
 
 ## 1.0.0-beta.5
 ### Changed

--- a/api/classes/LazyValue.js
+++ b/api/classes/LazyValue.js
@@ -54,7 +54,7 @@ class LazyValue {
    */
   getLazy () {
     if (this.#value) {
-      return this.#value
+      return Promise.resolve(this.#value)
     }
     return new Promise(resolve => {
       this.#promises.push({ resolve })

--- a/api/classes/LazyValue.unit.test.js
+++ b/api/classes/LazyValue.unit.test.js
@@ -1,0 +1,22 @@
+const LazyValue = require('./LazyValue')
+
+test('set a lazy value', () => {
+  const value = new LazyValue()
+  expect(value.get()).toBeUndefined()
+  value.set('foo')
+  expect(value.get()).toBe('foo')
+})
+
+test('await a lazy value one time', () => {
+  const value = new LazyValue()
+  expect(value.getLazy()).resolves.toBe('bar')
+  value.set('bar')
+})
+
+test('await a lazy value multiple times', () => {
+  const value = new LazyValue()
+  expect(value.getLazy()).resolves.toBe('baz')
+  expect(value.getLazy()).resolves.toBe('baz')
+  value.set('baz')
+  expect(value.getLazy()).resolves.toBe('baz')
+})

--- a/api/items.js
+++ b/api/items.js
@@ -132,11 +132,13 @@ class Items {
       throw new InvalidArgumentError('Argument \'item\' must be a valid object that\'s not an array')
     }
 
-    await this.#props.State.apply({
+    this.#props.State.apply({
       items: {
         [id]: set
       }
     })
+
+    this.#props.Events.emit('item.apply', id, set)
   }
 
   /**

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -68,6 +68,7 @@ bridge.events.on('item.stop', item => {
 | `item.play` | Emitted when an item is played, after an optional delay |
 | `item.stop` | Emitted when an item is stopped |
 | `item.end` | Emitted when an item ends, this will not trigger when an item is stopped |
+| `item.apply` | Emitted when an item data is applied to an item using the item.apply api, this can be used to react to item changes |
 | `shortcut` | Emitted when a shortcut is triggered |
 | `selection` | Emitted when the selection of the current client changes |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bridge",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bridge",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bridge",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/plugins/caspar/app/views/InspectorTemplate.jsx
+++ b/plugins/caspar/app/views/InspectorTemplate.jsx
@@ -55,10 +55,8 @@ export const InspectorTemplate = () => {
 
   function handleSave (newValue) {
     try {
-      const json = JSON.parse(newValue)
       handleNewValue({
         data: {
-          templateData: { $replace: json },
           caspar: {
             /*
             templateDataSource holds the actual data sent in commands

--- a/plugins/caspar/lib/handlers.js
+++ b/plugins/caspar/lib/handlers.js
@@ -179,3 +179,35 @@ bridge.events.on('item.end', async coldItem => {
     bridge.commands.executeCommand('scheduler.delay', `end:${hotItem.id}`, endDelay, 'items.endItem', coldItem)
   }
 })
+
+/*
+ * Handle changes to item data by updating the item
+ * with a parsed value of the same data in order for
+ * variables to be able to utilize it
+ */
+bridge.events.on('item.apply', (itemId, set) => {
+  /*
+   * Make sure that the apply operation actually
+   * modifies the templateDataSource value
+   */
+  if (!set?.data?.caspar?.templateDataSource) {
+    return
+  }
+
+  try {
+    /*
+     * Parse the data and
+     * apply it to the item
+     */
+    const structuredData = JSON.parse(set?.data?.caspar?.templateDataSource)
+    bridge.items.applyItem(itemId, {
+      data: {
+        caspar: {
+          data: { $replace: structuredData }
+        }
+      }
+    })
+  } catch (e) {
+    logger.warn('Failed to apply structured data to item with error: ', e)
+  }
+})


### PR DESCRIPTION
See CHANGELOG.md for additional details.

- Adds the `item.apply` event
- Moves parsing of template data from the front end code to a handler in the Caspar plugin