### PR TITLE
Add a compatibility mode for CasparCG prior to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - A volume item type for the Caspar plugin
 - Support for additional frame rates when calculating durations of items in the Caspar plugin
 - Status messages that indicate background activity to the user
+- A compatibility mode for servers running versions of CasparCG prior to 2.1.0
 
 ## 1.0.0-beta.5
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Developed for CasparCG but can control anything that supports OSC.
 - [CRON - triggers based on the time of day](https://github.com/axelboberg/bridge-plugin-cron)
 
 ## Compatibility notes  
-- Bridge works with Caspar CG Server 2.3 and up.
+- Bridge works best with CasparCG server 2.3 and up, although a compatibility mode is available for older setups.
 - Bridge provides data to HTML templates as JSON.
 
 ## Download and install  

--- a/plugins/caspar/app/components/ServerInput/index.jsx
+++ b/plugins/caspar/app/components/ServerInput/index.jsx
@@ -44,6 +44,12 @@ export const ServerInput = ({ data = {}, onChange = () => {}, onDelete = () => {
               <option value='1'>Secondary</option>
             </select>
           </div>
+          <div className='ServerInput-space' />
+          <div className='ServerInput-input'>
+            <h3>Compatibility mode</h3>
+            For servers prior to version 2.1.0, some functionality will be disabled<br/>
+            <input type='checkbox' className='Switch ServerInput-input--switch' checked={data?.compatibilityMode ?? false} onChange={e => handleInput('compatibilityMode', e.target.checked)} />
+          </div>
         </div>
         <div className='ServerInput-actions'>
           <button className='Button Button--ghost' onClick={() => handleDelete()}>Delete</button><br />

--- a/plugins/caspar/app/components/ServerInput/style.css
+++ b/plugins/caspar/app/components/ServerInput/style.css
@@ -19,6 +19,10 @@
   text-align: right;
 }
 
+.ServerInput-space {
+  height: 7px;
+}
+
 .ServerInput-input {
   margin-bottom: 10px;
 }
@@ -33,6 +37,10 @@
 
 .ServerInput-input input {
   margin-right: 5px;
+}
+
+.ServerInput-input--switch {
+  margin-top: 7px;
 }
 
 .ServerInput-flexInputs {

--- a/plugins/caspar/index.js
+++ b/plugins/caspar/index.js
@@ -122,7 +122,7 @@ exports.activate = async () => {
   bridge.settings.registerSetting({
     title: 'Server',
     group: 'Caspar CG',
-    description: 'Configure Caspar servers (supports server v2.3 and up)',
+    description: 'Configure Caspar servers',
     inputs: [
       { type: 'frame', uri: `${htmlPath}?path=settings/servers` }
     ]

--- a/plugins/caspar/lib/commands.js
+++ b/plugins/caspar/lib/commands.js
@@ -65,7 +65,8 @@ async function setupServer (description) {
   }
 
   const server = new Caspar({
-    reconnect: true
+    reconnect: true,
+    compatibilityMode: description?.compatibilityMode
   })
 
   server.on('status', newStatus => {
@@ -153,6 +154,8 @@ async function editServer (serverId, description) {
       }
       return description
     })
+
+  server.mode = description.compatibilityMode ? Caspar.mode.COMPATIBILITY : Caspar.mode.DEFAULT
 
   bridge.state.apply({
     plugins: {


### PR DESCRIPTION
Bridge utilizes the `REQ` parameter introduced to AMCP with version 2.1.0. This pull request adds basic support for servers that doesn't support `REQ` – while trading some functionality.